### PR TITLE
[FIX] pos_partner_limit

### DIFF
--- a/pos_partner_limit/models/res_partner.py
+++ b/pos_partner_limit/models/res_partner.py
@@ -58,6 +58,12 @@ class ResPartner(models.Model):
         partner_exists = self.search([
             ('vat', '=', partner['vat'])
         ])
+        if not partner_exists and partner['country_id']:
+            country_code = self.env['res.country'].browse(partner['country_id']).code
+            vat = country_code + partner['vat']
+            partner_exists = self.search([
+                ('vat', '=', vat)
+            ])
         if not partner['id'] and partner_exists:
             partner['id'] = partner_exists.id
         return super(ResPartner, self).create_from_ui(partner)


### PR DESCRIPTION
Add: create_from_ui method now uses country_id.code + partner.vat format if vat alone gets no results.