### PR TITLE
[IMP] 14.0 pms aldahotels kpi: add module 

### DIFF
--- a/pms_alda_kpis/__init__.py
+++ b/pms_alda_kpis/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pms_alda_kpis/__manifest__.py
+++ b/pms_alda_kpis/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2024 OsoTranquilo - José Luis Algara
+# Copyright 2024 Irlui Ramírez
+# From Consultores Hoteleros Integrales (ALDA Hotels) - 2024
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': 'PMS Alda Kpi',
+    'version': '14.0.1.0.0',
+    'category': 'PMS',
+    "summary": """ Information related of property Alda Kpis """,
+    "author": "Irlui Ramirez,José Luis Algara,Odoo Community Association (OCA)",
+    "depends": ["base", "pms", "pms_data_bi"],
+    'data': [
+        'views/pms_alda_kpi_views.xml',
+        'views/pms_alda_kpi_settings.xml',
+        'security/ir.model.access.csv',
+    ],
+    "application": True,
+    "installable": True,
+    "auto_install": False,
+    "license": "AGPL-3",
+}

--- a/pms_alda_kpis/models/__init__.py
+++ b/pms_alda_kpis/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pms_alda_ramp_up
+from . import pms_alda_kpis

--- a/pms_alda_kpis/models/pms_alda_kpis.py
+++ b/pms_alda_kpis/models/pms_alda_kpis.py
@@ -1,0 +1,45 @@
+# Copyright 2024 OsoTranquilo - José Luis Algara
+# Copyright 2024 Irlui Ramírez
+# From Consultores Hoteleros Integrales (ALDA Hotels) - 2024
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+
+class PMSAldaKpis(models.Model):
+    _name = "pms.alda.kpis"
+    _description = "Attribute to calculate Alda Kpi"
+    
+    name = fields.Selection(
+        string="Attribute Name Kpi",
+        selection=[
+            ("ramp_time", "Ramp Up Time"),
+            ("another_type", "Another Type"), 
+        ],
+        required=True,
+        help="Specify the name of the KPI attribute.",
+    )
+    
+    kpi_value = fields.Char(
+        string='Attribute Value Kpi',
+        required=True,
+        help="Specify the atrribute value of the KPI. In case Ramp Up Time, value are months from open date",
+    )
+
+    @api.constrains('name', 'kpi_value')
+    def _check_unique_name_and_value(self):
+        for record in self:
+            existing_kpi = self.search([('name', '=', record.name), ('id', '!=', record.id)])
+            if existing_kpi:
+                raise ValidationError(f"A KPI with the name '{record.name}' already exists. You can only modify the existing one.")
+            if record.name == 'ramp_time':
+                try:
+                    int(record.kpi_value)
+                except ValueError:
+                    raise ValidationError("The kpi_value for 'Ramp-Rate' must be an integer.")
+
+    @api.model
+    def get_available_kpi_names(self):
+        all_kpis = ["ramp_time", "another_type"]
+        used_kpis = self.search([]).mapped('name')
+        available_kpis = [(kpi, kpi.replace('_', ' ').title()) for kpi in all_kpis if kpi not in used_kpis]
+        return available_kpis

--- a/pms_alda_kpis/models/pms_alda_ramp_up.py
+++ b/pms_alda_kpis/models/pms_alda_ramp_up.py
@@ -9,12 +9,10 @@ from datetime import datetime
 class PmsProperty(models.Model):
     _inherit = "pms.property"
 
-    kpi_id = fields.Many2one('pms.alda.kpis', string='KPI', ondelete='cascade')
-
     is_ramp_up = fields.Boolean(
         string='Ramp-Up', 
         compute='_compute_state', 
-        default=True,
+        default=False,
         help="From the opening of a hotel the first 17 months a hotel has RAMP-UP status, from month 17 it has RAMP-RATE status.",
     )
     
@@ -31,37 +29,31 @@ class PmsProperty(models.Model):
         help="From the opening of a hotel the first 17 months a hotel has RAMP-UP status, from month 17 it has RAMP-RATE status.",
     )
 
-    @api.depends('kpi_id.kpi_value')
+    @api.model
     def _compute_state(self):
         for record in self:
-            if record.kpi_id.name == 'ramp_time':  
-                if record.open_date:
-                    open_date = fields.Datetime.from_string(record.open_date)
-                    today = fields.Date.context_today(self)
-                    value_kpi = int(record.kpi_id.kpi_value)
-                    diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
-                    record.is_ramp_up = diff_months < value_kpi
-                    record.is_ramp_rate = diff_months >= 17
-                else:
-                    record.is_ramp_up = False
-                    record.is_ramp_rate = False
+            if record.open_date:
+                open_date = fields.Date.from_string(record.open_date)
+                today = fields.Date.context_today(self)
+                #today = fields.Date.today()
+                diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
+                kpi_value = self.env['pms.alda.kpis'].search([('name', '=', 'ramp_time')])
+                record.is_ramp_up = diff_months < int(kpi_value.kpi_value)
+                record.is_ramp_rate = diff_months >= int(kpi_value.kpi_value)
             else:
                 record.is_ramp_up = False
                 record.is_ramp_rate = False
-    
-    @api.depends('kpi_id.kpi_value')
+
+    @api.model
     def _compute_months_to_ramp_rate(self):
         for record in self:
-            if record.kpi_id.name == 'ramp_time': 
-                if record.open_date:
-                    open_date = fields.Datetime.from_string(record.open_date)
-                    today = fields.Date.context_today(self)
-                    value_kpi = int(record.kpi_id.kpi_value)
-                    diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
-                    if diff_months < value_kpi:
-                        record.months_to_ramp_rate = value_kpi - diff_months
-                    else:
-                        record.months_to_ramp_rate = 0
+            if record.open_date:
+                open_date = fields.Date.from_string(record.open_date)
+                today = fields.Date.context_today(self)
+                diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
+                kpi_value = self.env['pms.alda.kpis'].search([('name', '=', 'ramp_time')])
+                if diff_months < int(kpi_value.kpi_value):
+                    record.months_to_ramp_rate = int(kpi_value.kpi_value) - diff_months
                 else:
                     record.months_to_ramp_rate = 0
             else:

--- a/pms_alda_kpis/models/pms_alda_ramp_up.py
+++ b/pms_alda_kpis/models/pms_alda_ramp_up.py
@@ -1,0 +1,68 @@
+# Copyright 2024 OsoTranquilo - José Luis Algara
+# Copyright 2024 Irlui Ramírez
+# From Consultores Hoteleros Integrales (ALDA Hotels) - 2024
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+from datetime import datetime
+
+class PmsProperty(models.Model):
+    _inherit = "pms.property"
+
+    kpi_id = fields.Many2one('pms.alda.kpis', string='KPI', ondelete='cascade')
+
+    is_ramp_up = fields.Boolean(
+        string='Ramp-Up', 
+        compute='_compute_state', 
+        default=True,
+        help="From the opening of a hotel the first 17 months a hotel has RAMP-UP status, from month 17 it has RAMP-RATE status.",
+    )
+    
+    is_ramp_rate = fields.Boolean(
+        string='Ramp-Rate', 
+        compute='_compute_state',
+        default=False,
+        help="From the opening of a hotel the first 17 months a hotel has RAMP-UP status, from month 17 it has RAMP-RATE status.",
+    )
+
+    months_to_ramp_rate = fields.Integer(
+        string='Month to Ramp-Rate', 
+        compute='_compute_months_to_ramp_rate',
+        help="From the opening of a hotel the first 17 months a hotel has RAMP-UP status, from month 17 it has RAMP-RATE status.",
+    )
+
+    @api.depends('kpi_id.kpi_value')
+    def _compute_state(self):
+        for record in self:
+            if record.kpi_id.name == 'ramp_time':  
+                if record.open_date:
+                    open_date = fields.Datetime.from_string(record.open_date)
+                    today = fields.Date.context_today(self)
+                    value_kpi = int(record.kpi_id.kpi_value)
+                    diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
+                    record.is_ramp_up = diff_months < value_kpi
+                    record.is_ramp_rate = diff_months >= 17
+                else:
+                    record.is_ramp_up = False
+                    record.is_ramp_rate = False
+            else:
+                record.is_ramp_up = False
+                record.is_ramp_rate = False
+    
+    @api.depends('kpi_id.kpi_value')
+    def _compute_months_to_ramp_rate(self):
+        for record in self:
+            if record.kpi_id.name == 'ramp_time': 
+                if record.open_date:
+                    open_date = fields.Datetime.from_string(record.open_date)
+                    today = fields.Date.context_today(self)
+                    value_kpi = int(record.kpi_id.kpi_value)
+                    diff_months = (today.year - open_date.year) * 12 + today.month - open_date.month
+                    if diff_months < value_kpi:
+                        record.months_to_ramp_rate = value_kpi - diff_months
+                    else:
+                        record.months_to_ramp_rate = 0
+                else:
+                    record.months_to_ramp_rate = 0
+            else:
+                record.months_to_ramp_rate = 0

--- a/pms_alda_kpis/security/ir.model.access.csv
+++ b/pms_alda_kpis/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_pms_alda_kpis,access_pms_alda_kpis,model_pms_alda_kpis,pms.group_pms_user,1,1,1,1
+access_pms_alda_kpis_manager,access_pms_alda_kpis_manager,model_pms_alda_kpis,pms.group_pms_manager,1,1,1,1
+access_pms_alda_kpis_user,access_pms_alda_kpis_user,model_pms_alda_kpis,base.group_user,1,0,0,0

--- a/pms_alda_kpis/views/pms_alda_kpi_settings.xml
+++ b/pms_alda_kpis/views/pms_alda_kpi_settings.xml
@@ -1,0 +1,49 @@
+<odoo>
+    <!-- Acción para abrir el formulario y vista de árbol de KPI -->
+    <record id="action_pms_alda_kpis" model="ir.actions.act_window">
+        <field name="name">KPI</field>
+        <field name="res_model">pms.alda.kpis</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create the Value KPI configurations
+            </p>
+        </field>
+    </record>
+
+    <!-- Vista de árbol para KPI -->
+    <record id="view_pms_alda_kpis_tree" model="ir.ui.view">
+        <field name="name">pms.alda.kpis.tree</field>
+        <field name="model">pms.alda.kpis</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="kpi_value"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Vista de formulario para KPI -->
+    <record id="view_pms_alda_kpis_form" model="ir.ui.view">
+        <field name="name">pms.alda.kpis.form</field>
+        <field name="model">pms.alda.kpis</field>
+        <field name="arch" type="xml">
+            <form string="KPI">
+                <sheet>
+                    <group>
+                        <field name="name" widget="selection" options="{'selection': 'get_available_kpi_names'}"/>
+                        <field name="kpi_value"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Submenú KPI bajo el menú existente PMS Management -->
+    <menuitem id="menu_pms_alda_kpis" 
+              name="KPI" 
+              parent="pms.pms_configuration_menu" 
+              sequence="65" 
+              action="action_pms_alda_kpis"
+              groups="pms.group_pms_manager"/>
+</odoo>

--- a/pms_alda_kpis/views/pms_alda_kpi_views.xml
+++ b/pms_alda_kpis/views/pms_alda_kpi_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pms_alda_kpi_form" model="ir.ui.view">
+        <field name="name">pms.alda.kpi.form</field>
+        <field name="model">pms.property</field>
+        <field name="inherit_id" ref="pms.pms_property_views_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='property_general']" position="inside">
+                <sheet>
+                    <div class="container">
+                        <div class="o_horizontal_separator">Alda Hotels Kpi's</div>
+                        <div class="o_row">
+                            <div class="o_col-8">
+                                <group>
+                                    <field name="is_ramp_up"/>
+                                    <field name="is_ramp_rate"/>
+                                    <field name="months_to_ramp_rate"/>
+                                </group>
+                            </div>
+                        </div>
+                    </div>
+                </sheet>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module allows to add a table of attributes (key-value pair) useful for hotel Kpi's calculations. 
In addition, it calculates and displays in the hotel record whether it is in Ramp-rate or Ramp-Up as well as the time to be in Ramp-rate.

Important: note that the calculation is made based on the hotel's opening date, it requires the open_date field in the pms_property. Installing pms_property_opening from PMS
